### PR TITLE
Make GitHub detect forth/*.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/forth/*.txt linguist-language=Forth


### PR DESCRIPTION
Hej,

Please merge this, if you'd like GitHub to detect the `.txt` files in the `forth` directories as Forth.

Tack!
